### PR TITLE
2021 updates to get json_statistics logged

### DIFF
--- a/scrimmage/tasks.py
+++ b/scrimmage/tasks.py
@@ -291,7 +291,7 @@ def arbitrary_tournament_data_collection_function(gamelog):
   # Parse the interesting data you want from the gamelog and return it here (but keep it small!)
   pnls = []
   i = 0
-  for n in range(100, 1100, 100):
+  for n in range(100, 600, 100):
     i = gamelog.find('Round #' + str(n), i)
     if i == -1:
       pnls.append('nan')

--- a/scrimmage/tasks.py
+++ b/scrimmage/tasks.py
@@ -304,7 +304,6 @@ def arbitrary_tournament_data_collection_function(gamelog):
       else:
         pnls.append('nan')
 
-  matches = re.search(r'Straights ([0-9]+) ([0-9]+)', gamelog)
   return {
     "Ar": gamelog.count("A raises"),
     "Br": gamelog.count("B raises"),
@@ -318,8 +317,6 @@ def arbitrary_tournament_data_collection_function(gamelog):
     "Bf": gamelog.count("B folds"),
     "Ash": gamelog.count("A shows"),
     "Bsh": gamelog.count("B shows"),
-    "Ast": int(matches.group(1)),
-    "Bst": int(matches.group(2)),
     "pnls": pnls
   }
 


### PR DESCRIPTION
Error thrown by regex searching for straights from 2020 variant causes json_statistics to not be logged this year's tournaments.